### PR TITLE
Allow for dynamic item height

### DIFF
--- a/lib/src/tree_view.dart
+++ b/lib/src/tree_view.dart
@@ -87,7 +87,7 @@ class TreeView extends StatefulWidget {
   /// by [ScrollController] to determine the offset of a node and scroll to it).
   ///
   /// Defaults to `40.0`.
-  final double nodeHeight;
+  final double? nodeHeight;
 
   /// The [ScrollController] passed to [ListView.controller].
   final ScrollController? scrollController;


### PR DESCRIPTION
Makes the `nodeHeight` property optional to allow for dynamic item height (= to allow for `itemExtent` passed to the `ListView` to be `null`).